### PR TITLE
Add article: Data Engineering's Shift from Imperative to Declarative

### DIFF
--- a/weekly/imperative-to-declarative-brad-coles.yaml
+++ b/weekly/imperative-to-declarative-brad-coles.yaml
@@ -1,0 +1,17 @@
+article:
+  link: "https://bradcoles.dev/blog/declarative-transformation.html"
+  author:
+    name: "Brad Coles"
+    linkedin: "https://www.linkedin.com/in/bradcoles"
+    twitter: ""
+  reviewer:
+    name: ""
+    linkedin: ""
+    twitter: ""
+  review: "A decade-long look at the shift from imperative to declarative across the full ELT stack — covering dbt, Delta Live Tables, Snowflake Dynamic Tables, Spark Declarative Pipelines, and Fabric Materialized Lake Views. Includes a timeline of the convergence, a practical comparison of procedural notebooks vs declarative frameworks, and a section on why AI amplifies the case for declarative tooling."
+  tags:
+    - dbt
+    - declarative
+    - spark
+    - delta-lake
+    - data-transformation


### PR DESCRIPTION
Submitting this article for consideration in an upcoming edition.

The piece covers the decade-long industry shift from imperative to declarative across the full ELT stack - dbt, Delta Live Tables, Snowflake Dynamic Tables, Spark Declarative Pipelines, and Fabric Materialized Lake Views. Vendor-neutral framing with a historical timeline and a section on why declarative tooling becomes more valuable in AI-assisted workflows.

https://bradcoles.dev/blog/declarative-transformation.html