### PR TITLE
Add Rows & Columns Summit - OLTP/OLAP convergence conference

### DIFF
--- a/weekly/rows-columns-summit.yml
+++ b/weekly/rows-columns-summit.yml
@@ -1,0 +1,8 @@
+article:
+  author:
+    linkedin: "https://www.linkedin.com/in/elizabeth-garrett-christensen/"
+    name: "Elizabeth Christensen"
+    twitter: "@sqlliz"
+  link: "https://rowsandcolumnssummit.com/"
+  review: "Andy Pavlo is keynoting Rows & Columns Summit, a free single-track conference on the OLTP-OLAP convergence. Practitioner talks on hybrid architectures, open table formats, CDC, purpose-built systems, and new database paradigms. September 22 in San Francisco. CFP open through August 8."
+  tags: "OLTP, OLAP, data architecture, conference, hybrid databases, open table formats, CDC"


### PR DESCRIPTION
Submitting Rows & Columns Summit (September 22, 2026, San Francisco) for consideration in an upcoming edition. Free, single-track practitioner conference on the OLTP-OLAP convergence, keynoted by Andy Pavlo. CFP closes August 8.