### PR TITLE
Add source-backed PCSO results archive methodology

### DIFF
--- a/weekly/source-backed-pcso-results-archive.yaml
+++ b/weekly/source-backed-pcso-results-archive.yaml
@@ -1,0 +1,17 @@
+article:
+  link: "https://lottolensph.com/research/pcso-results-data-coverage"
+  author:
+    name: "LottoLens PH"
+    linkedin: ""
+    twitter: ""
+  reviewer:
+    name: ""
+    linkedin: ""
+    twitter: ""
+  review: "A practical look at maintaining a source-backed public data archive across nine Philippine draw games. The report documents record normalization, row-level provenance, freshness gates that block publication when an expected draw window is missing, and an append-only policy that prevents later updates from rewriting historical results. It also states the archive's coverage limits and avoids treating historical frequencies as predictions."
+  tags:
+    - data-quality
+    - data-provenance
+    - data-pipelines
+    - open-data
+    - data-freshness


### PR DESCRIPTION
## Submission

A methodology and coverage report for maintaining a source-backed public results archive across nine Philippine draw games.

The article focuses on data-engineering concerns:

- normalized record structure across games and draw windows;
- row-level source provenance;
- freshness gates that stop publication when an expected window is missing;
- append-only historical records;
- explicit coverage limits and non-prediction boundaries.

The linked page is publicly readable and the current archive summary is updated from the same production data snapshot.

## Relationship and subject disclosure

I am submitting this on behalf of LottoLens PH, the publisher/maintainer of the linked resource. The dataset concerns lottery draw records. LottoLens PH does not sell tickets or accept wagers; this resource is limited to result verification and descriptive/reproducible analysis and does not claim prediction. Please close the proposal if gambling-related subject matter is outside this publication's scope.